### PR TITLE
Update to use Node.js 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   nuget-api-key-source:
     description: 'Source to scope the NuGet API Key to.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 branding:
   icon: package


### PR DESCRIPTION
Same as with https://github.com/NuGet/setup-nuget/pull/42, we are now seeing a warning when using actions that rely on Node 16 because Node 16 isn't supported anymore.

This PR updates to Node 20, which is the current active LTS version of node.

More info: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/