### PR TITLE
Update README.md to reflect v2 action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ for how to configure secrets on your repository.
 ```yaml
 steps:
 - uses: actions/checkout@master
-- uses: nuget/setup-nuget@v1
+- uses: nuget/setup-nuget@v2
   with:
     nuget-api-key: ${{ secrets.NuGetAPIKey }}
     nuget-version: '5.x'
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Setup NuGet.exe
-        uses: nuget/setup-nuget@v1
+        uses: nuget/setup-nuget@v2
         with:
           nuget-version: ${{ matrix.nuget }}
       - run: nuget restore MyProject.sln
@@ -71,10 +71,10 @@ Note: For this example, you'll need to enable [repeatable builds](https://devblo
 ```yaml
 steps:
 - uses: actions/checkout@master
-- uses: nuget/setup-nuget@v1
+- uses: nuget/setup-nuget@v2
   with:
     nuget-version: '5.x'
-- uses: actions/cache@v1
+- uses: actions/cache@v4
   id: cache
   with:
     path: ~/.nuget/packages


### PR DESCRIPTION
Update the main readme to reflect the release of the `v2` / node20 version.

Also took the liberty of updating the example using `actions/cache` to `v4` for the same reason.